### PR TITLE
feat: always show image controls

### DIFF
--- a/view/css/custom.css
+++ b/view/css/custom.css
@@ -285,16 +285,6 @@ main {
     max-height:98px;
 }
 
-/* Shrink wrap strategy 2 */
-.easyzoom {
-    position:relative;
-    display: inline-block;
-}
-.easyzoom img {
-    vertical-align: bottom;
-}
-
-
 .c50 {
     float:left;
     width:50%;
@@ -417,7 +407,6 @@ hr {
 
 #image_frame {
     width:100%;
-    height:790px;
     overflow:hidden;
     position:relative;
 }

--- a/view/edit.php
+++ b/view/edit.php
@@ -681,7 +681,7 @@ $media_path = $properties["media_path"];
 
                     <div>
                         <p>
-                            <label class="enthaltwrp">Enthält Spuren von:</label>
+                            <label class="enthaltwrp">Kann Spuren von enthalten:</label>
                             <span id="enthalt_spuren_collector"></span>
                             <span><input type="text" id="enthalt_spuren" data-type="enthalt"/></span>
                         </p>

--- a/view/js/image.js
+++ b/view/js/image.js
@@ -24,13 +24,6 @@ function setActiveImage(img_src) {
         var preview_height = (container_width * origHeight) / origWidth;
         
 
-        // 2. If height / width not bigger than container, just display it, otherwise apply easyzooom
-        var easyzoom = "";
-
-        if(origWidth > container_width || origHeight > container_height) {
-            easyzoom = "easyzoom";
-        }
-
         var html = '<div id="image_frame">' +
             '<img src="'+img_src+'" />' +
             '<div id="image_frame_controls1" class="image_frame_controls"><div id="ifc_lt" class="ifc">↖</div><div class="spacer"></div><div id="ifc_rt" class="ifc">↗</div><div class="spacer"></div>' +
@@ -58,8 +51,8 @@ function setActiveImage(img_src) {
 
         zimg.draggable();
 
-        center_img();
-
+        // by default fit to container.
+        fitToContainer();
     });
 }
 
@@ -93,7 +86,7 @@ $(document).on('click','#ifc_100',function() {
     center_img();
 });
 
-$(document).on('click','#ifc_fit',function() {
+function fitToContainer() {
     var theImage = new Image();
     theImage.src =  zimg.attr("src");
 
@@ -112,7 +105,9 @@ $(document).on('click','#ifc_fit',function() {
     }
 
     center_img();
-});
+};
+
+$(document).on('click','#ifc_fit', fitToContainer);
 
 function center_img() {
     var cw = cont.width();

--- a/view/js/product-open.js
+++ b/view/js/product-open.js
@@ -67,6 +67,7 @@ $(document).on('click','*[data-open_edit_id]',function(e) {
         $('#notice').val(product["notice"]);
         $('#company').val(product["productCorporation de_AT"]);
 
+        $('.nav-tabs a[href="#tab1"]').tab('show');
 
         // weight amount and weight amount unit calculations
         var pcSets = ["articleWeight","articleVolume","articleArea","articleLength","articleUses"];


### PR DESCRIPTION
removing fixed height for image_frame was enough for the controls to be
visible.

rename "Enthält Spuren von" zu "Kann Spuren von enthalten"

remove easyzoom code (has been replaced with different solution)

switch to tab1 when selecting a product → always displays warning that
user has to reserve a product.
