### PR TITLE
feat: provide "wie links" option for 2nd unit

### DIFF
--- a/view/edit.php
+++ b/view/edit.php
@@ -319,6 +319,7 @@ $taggroups = $stmt6->fetchAll();
                                     <label class="control-label">pro</label>
                                     <input type="text" class="myTextInput" id="nutrient_snd_amount" value="0">
                                     <select id="nutrient_snd_unit">
+                                        <option disabled selected value> -- wie links -- </option>
                                         <option>g</option>
                                         <option>ml</option>
                                     </select>

--- a/view/js/product-open.js
+++ b/view/js/product-open.js
@@ -147,7 +147,9 @@ $(document).on('click','*[data-open_edit_id]',function(e) {
         }
 
         // nutrient unit
-        $('#nutrient_snd_unit').val(product["nutrient_unit"]);
+        if (product["nutrient_snd_unit"]) {
+          $('#nutrient_snd_unit').val(product["nutrient_snd_unit"]);
+        }
 
 
         // allergene / ingredients


### PR DESCRIPTION
fix: use nutrient_snd_unit when filling a product
